### PR TITLE
Add name piece comparison logic

### DIFF
--- a/Gedcom7/GedcomCompatibilityReport.cs
+++ b/Gedcom7/GedcomCompatibilityReport.cs
@@ -44,9 +44,7 @@ namespace Gedcom7
 
         private GedcomComparisonReport CompareFiles(GedcomFile baselineFile, GedcomFile file)
         {
-            GedcomComparisonReport report = baselineFile.Compare(file);
-            file.ResetComparison();
-            return report;
+            return baselineFile.Compare(file);
         }
 
         private GedcomComparisonReport Compare(string baseline, GedcomFile file)

--- a/Gedcom7/GedcomFile.cs
+++ b/Gedcom7/GedcomFile.cs
@@ -103,6 +103,8 @@ namespace Gedcom7
             {
                 structure.AppendNonMatchingStructures(report.StructuresAdded);
             }
+            this.ResetComparison();
+            otherFile.ResetComparison();
 
             return report;
         }

--- a/Gedcom7/GedcomStructure.cs
+++ b/Gedcom7/GedcomStructure.cs
@@ -301,10 +301,14 @@ namespace Gedcom7
             // Save substructure matches.
             foreach (GedcomStructure sub in this.Substructures)
             {
-                float subScore;
-                GedcomStructure otherSub = sub.FindBestMatch(other.Substructures, out subScore);
-                if (subScore > 0)
+                while (!sub.IsMatchComplete)
                 {
+                    float subScore;
+                    GedcomStructure otherSub = sub.FindBestMatch(other.Substructures, out subScore);
+                    if (subScore <= 0)
+                    {
+                        break;
+                    }
                     sub.SaveMatch(otherSub);
                 }
             }

--- a/Tests/ComparisonTests.cs
+++ b/Tests/ComparisonTests.cs
@@ -127,15 +127,20 @@ namespace Tests
         [TestMethod]
         public void CompareSingleNamePiecesWithMultipleNamePieces()
         {
-            var note = new GedcomFile();
-            bool ok = note.Load("../../../samples/name-pieces-single.ged");
+            var singles = new GedcomFile();
+            bool ok = singles.Load("../../../samples/name-pieces-single.ged");
             Assert.IsTrue(ok);
 
-            var snote = new GedcomFile();
-            ok = snote.Load("../../../samples/name-pieces-multiple.ged");
+            var multiples = new GedcomFile();
+            ok = multiples.Load("../../../samples/name-pieces-multiple.ged");
             Assert.IsTrue(ok);
 
-            GedcomComparisonReport report = note.Compare(snote);
+            GedcomComparisonReport report = singles.Compare(multiples);
+            Assert.AreEqual(report.StructuresAdded.Count, 0);
+            Assert.AreEqual(report.StructuresRemoved.Count, 0);
+            Assert.AreEqual(report.CompatibilityPercentage, 100);
+
+            report = multiples.Compare(singles);
             Assert.AreEqual(report.StructuresAdded.Count, 0);
             Assert.AreEqual(report.StructuresRemoved.Count, 0);
             Assert.AreEqual(report.CompatibilityPercentage, 100);

--- a/Tests/ComparisonTests.cs
+++ b/Tests/ComparisonTests.cs
@@ -135,6 +135,7 @@ namespace Tests
             ok = multiples.Load("../../../samples/name-pieces-multiple.ged");
             Assert.IsTrue(ok);
 
+            // Verify that both compare equally.
             GedcomComparisonReport report = singles.Compare(multiples);
             Assert.AreEqual(report.StructuresAdded.Count, 0);
             Assert.AreEqual(report.StructuresRemoved.Count, 0);
@@ -144,6 +145,31 @@ namespace Tests
             Assert.AreEqual(report.StructuresAdded.Count, 0);
             Assert.AreEqual(report.StructuresRemoved.Count, 0);
             Assert.AreEqual(report.CompatibilityPercentage, 100);
+
+            var mismatch = new GedcomFile();
+            ok = mismatch.Load("../../../samples/name-pieces-multiple-mismatch.ged");
+            Assert.IsTrue(ok);
+
+            // Verify that mismatch does not compare equally.
+            report = singles.Compare(mismatch);
+            Assert.AreEqual(report.StructuresAdded.Count, 6);
+            Assert.AreEqual(report.StructuresRemoved.Count, 6);
+            Assert.AreEqual(report.CompatibilityPercentage, 50);
+
+            report = mismatch.Compare(singles);
+            Assert.AreEqual(report.StructuresAdded.Count, 6);
+            Assert.AreEqual(report.StructuresRemoved.Count, 6);
+            Assert.AreEqual(report.CompatibilityPercentage, 66);
+
+            report = multiples.Compare(mismatch);
+            Assert.AreEqual(report.StructuresAdded.Count, 6);
+            Assert.AreEqual(report.StructuresRemoved.Count, 6);
+            Assert.AreEqual(report.CompatibilityPercentage, 66);
+
+            report = mismatch.Compare(multiples);
+            Assert.AreEqual(report.StructuresAdded.Count, 6);
+            Assert.AreEqual(report.StructuresRemoved.Count, 6);
+            Assert.AreEqual(report.CompatibilityPercentage, 66);
         }
     }
 }

--- a/Tests/ComparisonTests.cs
+++ b/Tests/ComparisonTests.cs
@@ -123,5 +123,22 @@ namespace Tests
             Assert.AreEqual(report.StructuresRemoved.Count, 0);
             Assert.AreEqual(report.CompatibilityPercentage, 100);
         }
+
+        [TestMethod]
+        public void CompareSingleNamePiecesWithMultipleNamePieces()
+        {
+            var note = new GedcomFile();
+            bool ok = note.Load("../../../samples/name-pieces-single.ged");
+            Assert.IsTrue(ok);
+
+            var snote = new GedcomFile();
+            ok = snote.Load("../../../samples/name-pieces-multiple.ged");
+            Assert.IsTrue(ok);
+
+            GedcomComparisonReport report = note.Compare(snote);
+            Assert.AreEqual(report.StructuresAdded.Count, 0);
+            Assert.AreEqual(report.StructuresRemoved.Count, 0);
+            Assert.AreEqual(report.CompatibilityPercentage, 100);
+        }
     }
 }

--- a/Tests/samples/name-pieces-multiple-mismatch.ged
+++ b/Tests/samples/name-pieces-multiple-mismatch.ged
@@ -1,0 +1,18 @@
+﻿0 HEAD
+1 GEDC
+2 VERS 7.0
+0 @I1@ INDI
+1 NAME npfx1 npfx2 givn1 givn2 nick1 nick2 /spfx1 spfx2 surn1 surn2/ nsfx1 nsfx2
+2 NPFX npfx1
+2 NPFX npfx1
+2 GIVN givn1
+2 GIVN givn1
+2 NICK nick1
+2 NICK nick1
+2 SPFX spfx1
+2 SPFX spfx1
+2 SURN surn1
+2 SURN surn1
+2 NSFX nsfx1
+2 NSFX nsfx1
+0 TRLR

--- a/Tests/samples/name-pieces-multiple.ged
+++ b/Tests/samples/name-pieces-multiple.ged
@@ -1,0 +1,18 @@
+﻿0 HEAD
+1 GEDC
+2 VERS 7.0
+0 @I1@ INDI
+1 NAME npfx1 npfx2 givn1 givn2 nick1 nick2 /spfx1 spfx2 surn1 surn2/ nsfx1 nsfx2
+2 NPFX npfx1
+2 NPFX npfx2
+2 GIVN givn1
+2 GIVN givn2
+2 NICK nick1
+2 NICK nick2
+2 SPFX spfx1
+2 SPFX spfx2
+2 SURN surn1
+2 SURN surn2
+2 NSFX nsfx1
+2 NSFX nsfx2
+0 TRLR

--- a/Tests/samples/name-pieces-single.ged
+++ b/Tests/samples/name-pieces-single.ged
@@ -1,0 +1,12 @@
+﻿0 HEAD
+1 GEDC
+2 VERS 7.0
+0 @I1@ INDI
+1 NAME npfx1 npfx2 givn1 givn2 nick1 nick2 /spfx1 spfx2 surn1 surn2/ nsfx1 nsfx2
+2 NPFX npfx1 npfx2
+2 GIVN givn1 givn2
+2 NICK nick1 nick2
+2 SPFX spfx1 spfx2
+2 SURN surn1 surn2
+2 NSFX nsfx1 nsfx2
+0 TRLR


### PR DESCRIPTION
Per the GEDCOM spec and steering committee discussion, treat multiple name pieces with the same tag the same as a single structure with all the words in the payload.