### PR TITLE
Put whole GedValidate bin directory in artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,6 @@ jobs:
       if: steps.skip_check.outputs.should_skip != 'true'
       uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
       with:
-        name: Windows ${{matrix.configurations}} GedValidate.exe
-        path: ${{github.workspace}}/GedValidate/bin/${{env.BUILD_CONFIGURATION}}/net6.0/GedValidate.exe
+        name: Windows ${{matrix.configurations}} GedValidate
+        path: ${{github.workspace}}/GedValidate/bin/${{env.BUILD_CONFIGURATION}}/net6.0/
         retention-days: 5


### PR DESCRIPTION
Not just the .exe but also the .dlls it depends on

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the artifact upload process to allow for the entire directory of files to be uploaded instead of just a single executable. 
	- Changed the artifact name to a more general naming convention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->