### PR TITLE
Fix contents of zip file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Zip the directory
         shell: pwsh
         run: |
-          $source = "${{github.workspace}}/GedValidate/bin/${{env.BUILD_CONFIGURATION}}/net6.0/"
+          $source = "${{github.workspace}}/GedValidate/bin/${{env.BUILD_CONFIGURATION}}/net6.0/*"
           $destination = "${{github.workspace}}/GedValidate/bin/${{env.BUILD_CONFIGURATION}}/net6.0/Windows-${{env.BUILD_CONFIGURATION}}-GedValidate.zip"
           Compress-Archive -Path $source -DestinationPath $destination
 


### PR DESCRIPTION
Don't include the net6.0 directory as a level in the file, just put the contents in the root of the zip file.