### PR TITLE
Permit any text media type in FORM

### DIFF
--- a/Gedcom7/GedcomStructure.cs
+++ b/Gedcom7/GedcomStructure.cs
@@ -787,9 +787,9 @@ namespace Gedcom7
                         {
                             return ErrorMessage("\"" + this.LineVal + "\" is not a valid media type");
                         }
-                        if (this.Tag == "MIME" && this.LineVal != "text/plain" && this.LineVal != "text/html")
+                        if (this.Tag == "MIME" && !this.LineVal.StartsWith("text/"))
                         {
-                            return ErrorMessage(this.Tag + " payload must be text/plain or text/html");
+                            return ErrorMessage(this.Tag + " payload must be a text type");
                         }
                         break;
                     case "http://www.w3.org/2001/XMLSchema#Language":

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It contains:
 The same Gedcom7 library is used by the online web site tools:
 - [GEDCOM 5.5.1 to 7.0 converter](https://magikeygedcomconverter.azurewebsites.net)
 - [GEDCOM Validator](https://magikeygedcomconverter.azurewebsites.net/Validate)
-- [FamilySearch GEDCOM 7 Compatability web tool](https://magikeygedcomconverter.azurewebsites.net/Compatability)
+- [FamilySearch GEDCOM 7 Compatibility web tool](https://magikeygedcomconverter.azurewebsites.net/Compatibility)
   which should give the same results as the GedCompare command-line tool here.
 
 # Prerequisites

--- a/Tests/SchemaTests.cs
+++ b/Tests/SchemaTests.cs
@@ -794,11 +794,11 @@ namespace Tests
         [TestMethod]
         public void ValidateExactDatePayloadType()
         {
-            // Try some valid name values.
+            // Try some valid date values.
             ValidateValidExactDatePayload("3 DEC 2023");
             ValidateValidExactDatePayload("03 DEC 2023");
 
-            // Try some invalid name values.
+            // Try some invalid date values.
             ValidateInvalidExactDatePayload("invalid");
             ValidateInvalidExactDatePayload("3 dec 2023");
             ValidateInvalidExactDatePayload("3 JUNE 2023");
@@ -1140,7 +1140,14 @@ namespace Tests
 0 @N1@ SNOTE Test
 1 MIME text/unknown
 0 TRLR
-", "Line 5: MIME payload must be text/plain or text/html");
+");
+            ValidateGedcomText(@"0 HEAD
+1 GEDC
+2 VERS 5.5.1
+0 @N1@ SNOTE Test
+1 MIME image/unknown
+0 TRLR
+", "Line 5: MIME payload must be a text type");
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #281

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for the "MIME" tag to accept any text-based media type (starting with "text/") instead of only "text/plain" or "text/html".
  - Updated error messages to reflect the broader acceptance of text types for MIME payloads.

- **Tests**
  - Added test cases to ensure non-text MIME types are correctly rejected with an updated error message.
  - Clarified test comments for better understanding of test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->