### PR TITLE
Upgrade github workflows to use windows 2022

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         configurations: [Debug, Release]
-    runs-on: windows-2019
+    runs-on: windows-2022
     env:
       # Path to the solution file relative to the root of the project.
       SOLUTION_FILE_PATH: Gedcom7.sln

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   deploy:
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0  # v2.12.0

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It contains:
 The same Gedcom7 library is used by the online web site tools:
 - [GEDCOM 5.5.1 to 7.0 converter](https://magikeygedcomconverter.azurewebsites.net)
 - [GEDCOM Validator](https://magikeygedcomconverter.azurewebsites.net/Validate)
-- [FamilySearch GEDCOM 7 Compatability web tool](https://magikeygedcomconverter.azurewebsites.net/Compatability)
+- [FamilySearch GEDCOM 7 Compatibility web tool](https://magikeygedcomconverter.azurewebsites.net/Compatibility)
   which should give the same results as the GedCompare command-line tool here.
 
 # Prerequisites


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Windows runner environment for build and release processes to use a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->