### PR TITLE
Allow passing GEDCOM-registries path to LoadFromUrl

### DIFF
--- a/GedcomCommon/GedcomFile.cs
+++ b/GedcomCommon/GedcomFile.cs
@@ -167,8 +167,9 @@ namespace GedcomCommon
         /// Load a GEDCOM file from a specified URL.
         /// </summary>
         /// <param name="url">URL to file to load</param>
+        /// <param name="gedcomRegistriesPath">GEDCOM registries path</param>
         /// <returns>List of 0 or more error messages</returns>
-        public List<string> LoadFromUrl(string url)
+        public List<string> LoadFromUrl(string url, string gedcomRegistriesPath = null)
         {
             this.Path = url;
 
@@ -178,7 +179,7 @@ namespace GedcomCommon
             {
                 using (var reader = new StreamReader(content))
                 {
-                    return LoadFromStreamReader(reader);
+                    return LoadFromStreamReader(reader, GedcomVersion.Unknown, gedcomRegistriesPath);
                 }
             }
         }

--- a/Tests/SchemaTests.cs
+++ b/Tests/SchemaTests.cs
@@ -15,6 +15,7 @@ namespace Tests
     public class SchemaTests
     {
         private const string TEST_FILES_BASE_PATH = "../../../../external/GEDCOM-registries/registry_tools/GEDCOM.io/testfiles/gedcom70";
+        private const string TEST_FILES_REMOTE_PATH = "https://gedcom.io/testfiles/gedcom70/";
 
         [TestMethod]
         public void LoadStructureSchema()
@@ -32,6 +33,22 @@ namespace Tests
         {
             var file = new GedcomFile();
             List<string> errors = file.LoadFromPath(path);
+            string error = null;
+            if (errors.Count == 0)
+            {
+                errors.AddRange(file.Validate());
+            }
+            if (errors.Count > 0)
+            {
+                error = string.Join("\n", errors);
+            }
+            Assert.AreEqual(expected_result, error);
+        }
+
+        public static void ValidateRemoteGedcomFile(string url, string expected_result = null)
+        {
+            var file = new GedcomFile();
+            List<string> errors = file.LoadFromUrl(url);
             string error = null;
             if (errors.Count == 0)
             {
@@ -128,6 +145,12 @@ namespace Tests
         public void ValidateFileMaximal70()
         {
             ValidateGedcomFile(Path.Combine(TEST_FILES_BASE_PATH, "maximal70.ged"));
+        }
+
+        [TestMethod]
+        public void ValidateRemoteFileMaximal70()
+        {
+            ValidateRemoteGedcomFile(TEST_FILES_REMOTE_PATH + "maximal70.ged");
         }
 
         [TestMethod]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for loading and validating GEDCOM files directly from remote URLs.
- **Tests**
  - Introduced new tests to validate GEDCOM files accessed from remote sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->