### PR TITLE
Add support for GEDCOM 5.5.1 CONC

### DIFF
--- a/GedcomCommon/GedcomStructure.cs
+++ b/GedcomCommon/GedcomStructure.cs
@@ -101,6 +101,10 @@ namespace GedcomCommon
 
         // Functions and derived data members.
         public override string ToString() => this.OriginalLine;
+        public void ConcatenatePayload(string more)
+        {
+            LineVal += more;
+        }
         public bool IsNoteType => this.Tag == "NOTE" || this.Tag == "SNOTE";
         public bool IsNamePieceType => this.Tag == "NPFX" || this.Tag == "GIVN" || this.Tag == "NICK" || this.Tag == "SPFX" || this.Tag == "SURN" || this.Tag == "NSFX";
         public GedcomStructure FindFirstSubstructure(string tag) => this.Substructures.Find(x => x.Tag == tag);

--- a/GedcomLoader/GedcomFile.cs
+++ b/GedcomLoader/GedcomFile.cs
@@ -136,6 +136,20 @@ namespace GedcomLoader
             while ((line = reader.ReadLine()) != null)
             {
                 this.LineCount++;
+
+                if (this.GedcomVersion == GedcomVersion.V551)
+                {
+                    int level = structurePath.Count();
+                    if (level > 0) {
+                        string conc = $"{level} CONC ";
+                        if (line.StartsWith(conc))
+                        {
+                            structurePath.Last().ConcatenatePayload(line.Substring(conc.Length));
+                            continue;
+                        }
+                    }
+                }
+
                 var s = new GedcomStructure();
                 // TODO: Move these registrations to static initialization inside the Gedcom551 and Gedcom7 namespaces
                 s.RegisterPayloadParser("https://gedcom.io/terms/v5.5.1/type-LANGUAGE_ID", Gedcom551.LanguageId.ValidateLanguageId);

--- a/Tests/SchemaTests.cs
+++ b/Tests/SchemaTests.cs
@@ -828,7 +828,6 @@ namespace Tests
         // Test files from the test-files repository.
 
         [TestMethod]
-        [Ignore("Known issue: CONC validation not implemented yet")]
         public void ValidateTestFileAtSign()
         {
             ValidateGedcomFile(Path.Combine(TEST_FILES_BASE_551_PATH2, "atsign.ged"));
@@ -942,10 +941,10 @@ namespace Tests
         }
 
         [TestMethod]
-        [Ignore("Known issue: xref-case.ged validation not implemented yet")]
         public void ValidateTestFileXrefCase()
         {
-            ValidateGedcomFile(Path.Combine(TEST_FILES_BASE_551_PATH2, "xref-case.ged"));
+            ValidateGedcomFile(Path.Combine(TEST_FILES_BASE_551_PATH2, "xref-case.ged"),
+                "Line 3: @test@ has no associated record");
         }
     }
 


### PR DESCRIPTION
Enable 2 more GEDCOM 5.5.1 tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced GEDCOM 5.5.1 parsing to properly handle multi-part continuation lines.

* **Tests**
  * Enabled additional validation tests for GEDCOM 5.5.1 file format compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->