### PR TITLE
Add support for validating FamilySearch GEDCOM 7.1 files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,11 +76,17 @@ jobs:
         working-directory: ./Tests/bin/${{env.BUILD_CONFIGURATION}}/net8.0
         run: vstest.console.exe Tests.dll /Logger:trx
 
-      - name: Validate GEDCOM.io test files
+      - name: Validate GEDCOM.io v7.0 test files
         if: steps.skip_check.outputs.should_skip != 'true'
         working-directory: ${{github.workspace}}/GedValidate/bin/${{env.BUILD_CONFIGURATION}}/net8.0/
         run: |
           .\GedValidate.exe ${{github.workspace}}\external\GEDCOM-registries ${{github.workspace}}\external\GEDCOM-registries\registry_tools\GEDCOM.io\testfiles\gedcom70\
+
+      - name: Validate GEDCOM.io v7.1 test files
+        if: steps.skip_check.outputs.should_skip != 'true'
+        working-directory: ${{github.workspace}}/GedValidate/bin/${{env.BUILD_CONFIGURATION}}/net8.0/
+        run: |
+          .\GedValidate.exe ${{github.workspace}}\external\GEDCOM-registries ${{github.workspace}}\external\GEDCOM-registries\registry_tools\GEDCOM.io\testfiles\gedcom71\
 
       - name: Validate test-files test files
         if: steps.skip_check.outputs.should_skip != 'true'

--- a/GedcomCommon/CalendarSchema.cs
+++ b/GedcomCommon/CalendarSchema.cs
@@ -41,13 +41,6 @@ namespace GedcomCommon
 
         static Dictionary<string, CalendarSchema> s_CalendarsByTag = new Dictionary<string, CalendarSchema>();
 
-        /// <summary>
-        /// Check whether this schema applies to a given GEDCOM version.
-        /// </summary>
-        /// <param name="version">GEDCOM version</param>
-        /// <returns>true if applies, false if not</returns>
-        private bool HasVersion(GedcomVersion version) => GedcomStructureSchema.UriHasVersion(this.Uri, version);
-
         public static void LoadAll(GedcomVersion version, string gedcomRegistriesPath)
         {
             if (s_CalendarsByTag.Count > 0)
@@ -55,6 +48,29 @@ namespace GedcomCommon
                 return;
             }
             MonthSchema.LoadAll(gedcomRegistriesPath);
+
+            // Read the manifest file to get the list of calendar files for this version.
+            var standardManifestPath = Path.Combine(gedcomRegistriesPath, "manifest", "standard", "manifest-" + GedcomStructureSchema.GetGedcomVersionString(version) + "-en-US.tsv");
+            var calendarFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            if (File.Exists(standardManifestPath))
+            {
+                using var manifestReader = new StreamReader(standardManifestPath);
+
+                // Skip header line.
+                manifestReader.ReadLine();
+                string line;
+                while ((line = manifestReader.ReadLine()) != null)
+                {
+                    line = line.Trim();
+                    if (line.StartsWith("calendar/standard/", StringComparison.OrdinalIgnoreCase))
+                    {
+                        // Convert the manifest path to just the filename for comparison.
+                        var filename = Path.GetFileName(line);
+                        calendarFiles.Add(filename);
+                    }
+                }
+            }
+
             var path = Path.Combine(gedcomRegistriesPath, "calendar/standard");
             string[] files;
             try
@@ -68,14 +84,17 @@ namespace GedcomCommon
             }
             foreach (string filename in files)
             {
+                // Only load files that are in the manifest.
+                var justFilename = Path.GetFileName(filename);
+                if (!calendarFiles.Contains(justFilename))
+                {
+                    continue;
+                }
+
                 var deserializer = new DeserializerBuilder().Build();
                 using var reader = new StreamReader(filename);
                 var dictionary = deserializer.Deserialize<Dictionary<object, object>>(reader);
                 var schema = new CalendarSchema(dictionary);
-                if (!schema.HasVersion(version))
-                {
-                    continue;
-                }
                 s_CalendarsByTag.Add(schema.StandardTag, schema);
             }
         }

--- a/GedcomCommon/CalendarSchema.cs
+++ b/GedcomCommon/CalendarSchema.cs
@@ -51,24 +51,37 @@ namespace GedcomCommon
 
             // Read the manifest file to get the list of calendar files for this version.
             var standardManifestPath = Path.Combine(gedcomRegistriesPath, "manifest", "standard", "manifest-" + GedcomStructureSchema.GetGedcomVersionString(version) + "-en-US.tsv");
-            var calendarFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            if (File.Exists(standardManifestPath))
+            if (!File.Exists(standardManifestPath))
             {
-                using var manifestReader = new StreamReader(standardManifestPath);
+                throw new FileNotFoundException($"Standard manifest file not found: {standardManifestPath}", standardManifestPath);
+            }
 
+            var calendarFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            using (var manifestReader = new StreamReader(standardManifestPath))
+            {
                 // Skip header line.
                 manifestReader.ReadLine();
                 string line;
                 while ((line = manifestReader.ReadLine()) != null)
                 {
-                    line = line.Trim();
-                    if (line.StartsWith("calendar/standard/", StringComparison.OrdinalIgnoreCase))
+                    if (string.IsNullOrWhiteSpace(line))
+                    {
+                        continue;
+                    }
+
+                    // The manifest is TSV; the first column is the path.
+                    var manifestPath = line.Split('\t')[0].Trim();
+                    if (manifestPath.StartsWith("calendar/standard/", StringComparison.OrdinalIgnoreCase))
                     {
                         // Convert the manifest path to just the filename for comparison.
-                        var filename = Path.GetFileName(line);
-                        calendarFiles.Add(filename);
+                        calendarFiles.Add(Path.GetFileName(manifestPath));
                     }
                 }
+            }
+
+            if (calendarFiles.Count == 0)
+            {
+                throw new InvalidDataException($"No calendar files were found in manifest: {standardManifestPath}");
             }
 
             var path = Path.Combine(gedcomRegistriesPath, "calendar/standard");

--- a/GedcomCommon/CalendarSchema.cs
+++ b/GedcomCommon/CalendarSchema.cs
@@ -50,39 +50,7 @@ namespace GedcomCommon
             MonthSchema.LoadAll(gedcomRegistriesPath);
 
             // Read the manifest file to get the list of calendar files for this version.
-            var standardManifestPath = Path.Combine(gedcomRegistriesPath, "manifest", "standard", "manifest-" + GedcomStructureSchema.GetGedcomVersionString(version) + "-en-US.tsv");
-            if (!File.Exists(standardManifestPath))
-            {
-                throw new FileNotFoundException($"Standard manifest file not found: {standardManifestPath}", standardManifestPath);
-            }
-
-            var calendarFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            using (var manifestReader = new StreamReader(standardManifestPath))
-            {
-                // Skip header line.
-                manifestReader.ReadLine();
-                string line;
-                while ((line = manifestReader.ReadLine()) != null)
-                {
-                    if (string.IsNullOrWhiteSpace(line))
-                    {
-                        continue;
-                    }
-
-                    // The manifest is TSV; the first column is the path.
-                    var manifestPath = line.Split('\t')[0].Trim();
-                    if (manifestPath.StartsWith("calendar/standard/", StringComparison.OrdinalIgnoreCase))
-                    {
-                        // Convert the manifest path to just the filename for comparison.
-                        calendarFiles.Add(Path.GetFileName(manifestPath));
-                    }
-                }
-            }
-
-            if (calendarFiles.Count == 0)
-            {
-                throw new InvalidDataException($"No calendar files were found in manifest: {standardManifestPath}");
-            }
+            var calendarFiles = GedcomStructureSchema.LoadManifestFilenames(gedcomRegistriesPath, version, "calendar/standard/");
 
             var path = Path.Combine(gedcomRegistriesPath, "calendar/standard");
             string[] files;

--- a/GedcomCommon/EnumerationSet.cs
+++ b/GedcomCommon/EnumerationSet.cs
@@ -42,13 +42,6 @@ namespace GedcomCommon
 
         static Dictionary<string, EnumerationSet> s_EnumerationSets = new Dictionary<string, EnumerationSet>();
 
-        /// <summary>
-        /// Check whether this schema applies to a given GEDCOM version.
-        /// </summary>
-        /// <param name="version">GEDCOM version</param>
-        /// <returns>true if applies, false if not</returns>
-        private bool HasVersion(GedcomVersion version) => GedcomStructureSchema.UriHasVersion(this.Uri, version);
-
         public static void LoadAll(GedcomVersion version, string gedcomRegistriesPath)
         {
             if (s_EnumerationSets.Count > 0)
@@ -56,6 +49,29 @@ namespace GedcomCommon
                 return;
             }
             EnumerationValue.LoadAll(gedcomRegistriesPath);
+
+            // Read the manifest file to get the list of enumeration-set files for this version.
+            var standardManifestPath = Path.Combine(gedcomRegistriesPath, "manifest", "standard", "manifest-" + GedcomStructureSchema.GetGedcomVersionString(version) + "-en-US.tsv");
+            var enumSetFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            if (File.Exists(standardManifestPath))
+            {
+                using var manifestReader = new StreamReader(standardManifestPath);
+
+                // Skip header line.
+                manifestReader.ReadLine();
+                string line;
+                while ((line = manifestReader.ReadLine()) != null)
+                {
+                    line = line.Trim();
+                    if (line.StartsWith("enumeration-set/standard/", StringComparison.OrdinalIgnoreCase))
+                    {
+                        // Convert the manifest path to just the filename for comparison.
+                        var filename = Path.GetFileName(line);
+                        enumSetFiles.Add(filename);
+                    }
+                }
+            }
+
             var path = Path.Combine(gedcomRegistriesPath, "enumeration-set", "standard");
             string[] files;
             try
@@ -69,14 +85,17 @@ namespace GedcomCommon
             }
             foreach (string filename in files)
             {
+                // Only load files that are in the manifest.
+                var justFilename = Path.GetFileName(filename);
+                if (!enumSetFiles.Contains(justFilename))
+                {
+                    continue;
+                }
+
                 var deserializer = new DeserializerBuilder().Build();
                 using var reader = new StreamReader(filename);
                 var dictionary = deserializer.Deserialize<Dictionary<object, object>>(reader);
                 var schema = new EnumerationSet(dictionary);
-                if (!schema.HasVersion(version))
-                {
-                    continue;
-                }
                 s_EnumerationSets.Add(schema.Uri, schema);
             }
         }

--- a/GedcomCommon/EnumerationSet.cs
+++ b/GedcomCommon/EnumerationSet.cs
@@ -51,39 +51,7 @@ namespace GedcomCommon
             EnumerationValue.LoadAll(gedcomRegistriesPath);
 
             // Read the manifest file to get the list of enumeration-set files for this version.
-            var standardManifestPath = Path.Combine(gedcomRegistriesPath, "manifest", "standard", "manifest-" + GedcomStructureSchema.GetGedcomVersionString(version) + "-en-US.tsv");
-            if (!File.Exists(standardManifestPath))
-            {
-                throw new FileNotFoundException($"Standard manifest file not found: {standardManifestPath}", standardManifestPath);
-            }
-
-            var enumSetFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            using (var manifestReader = new StreamReader(standardManifestPath))
-            {
-                // Skip header line.
-                manifestReader.ReadLine();
-                string line;
-                while ((line = manifestReader.ReadLine()) != null)
-                {
-                    if (string.IsNullOrWhiteSpace(line))
-                    {
-                        continue;
-                    }
-
-                    // The manifest is TSV; the first column is the path.
-                    var manifestPath = line.Split('\t')[0].Trim();
-                    if (manifestPath.StartsWith("enumeration-set/standard/", StringComparison.OrdinalIgnoreCase))
-                    {
-                        // Convert the manifest path to just the filename for comparison.
-                        enumSetFiles.Add(Path.GetFileName(manifestPath));
-                    }
-                }
-            }
-
-            if (enumSetFiles.Count == 0)
-            {
-                throw new InvalidDataException($"No enumeration-set files were found in manifest: {standardManifestPath}");
-            }
+            var enumSetFiles = GedcomStructureSchema.LoadManifestFilenames(gedcomRegistriesPath, version, "enumeration-set/standard/");
 
             var path = Path.Combine(gedcomRegistriesPath, "enumeration-set", "standard");
             string[] files;

--- a/GedcomCommon/EnumerationSet.cs
+++ b/GedcomCommon/EnumerationSet.cs
@@ -52,24 +52,37 @@ namespace GedcomCommon
 
             // Read the manifest file to get the list of enumeration-set files for this version.
             var standardManifestPath = Path.Combine(gedcomRegistriesPath, "manifest", "standard", "manifest-" + GedcomStructureSchema.GetGedcomVersionString(version) + "-en-US.tsv");
-            var enumSetFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            if (File.Exists(standardManifestPath))
+            if (!File.Exists(standardManifestPath))
             {
-                using var manifestReader = new StreamReader(standardManifestPath);
+                throw new FileNotFoundException($"Standard manifest file not found: {standardManifestPath}", standardManifestPath);
+            }
 
+            var enumSetFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            using (var manifestReader = new StreamReader(standardManifestPath))
+            {
                 // Skip header line.
                 manifestReader.ReadLine();
                 string line;
                 while ((line = manifestReader.ReadLine()) != null)
                 {
-                    line = line.Trim();
-                    if (line.StartsWith("enumeration-set/standard/", StringComparison.OrdinalIgnoreCase))
+                    if (string.IsNullOrWhiteSpace(line))
+                    {
+                        continue;
+                    }
+
+                    // The manifest is TSV; the first column is the path.
+                    var manifestPath = line.Split('\t')[0].Trim();
+                    if (manifestPath.StartsWith("enumeration-set/standard/", StringComparison.OrdinalIgnoreCase))
                     {
                         // Convert the manifest path to just the filename for comparison.
-                        var filename = Path.GetFileName(line);
-                        enumSetFiles.Add(filename);
+                        enumSetFiles.Add(Path.GetFileName(manifestPath));
                     }
                 }
+            }
+
+            if (enumSetFiles.Count == 0)
+            {
+                throw new InvalidDataException($"No enumeration-set files were found in manifest: {standardManifestPath}");
             }
 
             var path = Path.Combine(gedcomRegistriesPath, "enumeration-set", "standard");

--- a/GedcomCommon/GedcomStructureSchema.cs
+++ b/GedcomCommon/GedcomStructureSchema.cs
@@ -121,28 +121,6 @@ namespace GedcomCommon
             return (version == GedcomVersion.V70 || version == GedcomVersion.V71 || version == GedcomVersion.All);
         }
 
-        /// <summary>
-        /// Check whether this schema applies to a given GEDCOM version.
-        /// </summary>
-        /// <param name="version">GEDCOM version</param>
-        /// <returns>true if applies, false if not</returns>
-        public bool HasVersion(GedcomVersion version)
-        {
-            Debug.Assert(version != GedcomVersion.Unknown);
-            if (IsDocumented && !UriHasVersion(this.Uri, version))
-            {
-                return false;
-            }
-            foreach (string uri in Substructures.Keys)
-            {
-                if (!UriHasVersion(uri, version))
-                {
-                    return false;
-                }
-            }
-            return true;
-        }
-
         GedcomStructureSchema(Dictionary<object, object> dictionary)
         {
             this.Lang = dictionary["lang"] as string;
@@ -247,6 +225,21 @@ namespace GedcomCommon
             s_StructureSchemasByVersion[(int)version][structureSchemaKey] = schema;
         }
 
+        public static string GetGedcomVersionString(GedcomVersion version)
+        {
+            switch (version)
+            {
+                case GedcomVersion.V551:
+                    return "5.5.1";
+                case GedcomVersion.V70:
+                    return "7.0";
+                case GedcomVersion.V71:
+                    return "7.1";
+                default:
+                    return "Unknown";
+            }
+        }
+
         public static void LoadAll(GedcomVersion version, string gedcomRegistriesPath = null)
         {
             Debug.Assert(version != GedcomVersion.Unknown && version != GedcomVersion.All);
@@ -260,18 +253,44 @@ namespace GedcomCommon
                 string baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
                 gedcomRegistriesPath = Path.GetFullPath(Path.Combine(baseDirectory, "..", "..", "..", "..", "..", "gedcom7", "external", "GEDCOM-registries"));
             }
-            var path = Path.Combine(gedcomRegistriesPath, "structure", "standard");
-            string[] files = Directory.GetFiles(path);
+            var standardManifestPath = Path.Combine(gedcomRegistriesPath, "manifest", "standard", "manifest-" + GetGedcomVersionString(version) + "-en-US.tsv");
+
+            // Read the manifest file to get the list of structure files for this version.
+            var structureFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            if (File.Exists(standardManifestPath))
+            {
+                using var manifestReader = new StreamReader(standardManifestPath);
+
+                // Skip header line.
+                manifestReader.ReadLine();
+                string line;
+                while ((line = manifestReader.ReadLine()) != null)
+                {
+                    line = line.Trim();
+                    if (line.StartsWith("structure/standard/", StringComparison.OrdinalIgnoreCase))
+                    {
+                        // Convert the manifest path to just the filename for comparison.
+                        var filename = Path.GetFileName(line);
+                        structureFiles.Add(filename);
+                    }
+                }
+            }
+
+            var standardStructurePath = Path.Combine(gedcomRegistriesPath, "structure", "standard");
+            string[] files = Directory.GetFiles(standardStructurePath);
             foreach (string filename in files)
             {
+                // Only load files that are in the manifest.
+                var justFilename = Path.GetFileName(filename);
+                if (!structureFiles.Contains(justFilename))
+                {
+                    continue;
+                }
+
                 var deserializer = new DeserializerBuilder().Build();
                 using var reader = new StreamReader(filename);
                 var dictionary = deserializer.Deserialize<Dictionary<object, object>>(reader);
                 var schema = new GedcomStructureSchema(dictionary);
-                if (!schema.HasVersion(version))
-                {
-                    continue;
-                }
                 s_StructureSchemasByUri[schema.Uri] = schema;
                 if (schema.Superstructures.Count == 0)
                 {

--- a/GedcomCommon/GedcomStructureSchema.cs
+++ b/GedcomCommon/GedcomStructureSchema.cs
@@ -240,19 +240,14 @@ namespace GedcomCommon
             }
         }
 
-        public static void LoadAll(GedcomVersion version, string gedcomRegistriesPath = null)
+        /// <summary>
+        /// Reads a GEDCOM-registries standard manifest TSV and returns the set of filenames
+        /// whose first column starts with <paramref name="pathPrefix"/>.
+        /// Throws <see cref="FileNotFoundException"/> if the manifest does not exist and
+        /// <see cref="InvalidDataException"/> if no matching entries are found.
+        /// </summary>
+        public static HashSet<string> LoadManifestFilenames(string gedcomRegistriesPath, GedcomVersion version, string pathPrefix)
         {
-            Debug.Assert(version != GedcomVersion.Unknown && version != GedcomVersion.All);
-            if (s_StructureSchemasByVersion[(int)version].Count > 0)
-            {
-                // Already loaded.
-                return;
-            }
-            if (gedcomRegistriesPath == null)
-            {
-                string baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
-                gedcomRegistriesPath = Path.GetFullPath(Path.Combine(baseDirectory, "..", "..", "..", "..", "..", "gedcom7", "external", "GEDCOM-registries"));
-            }
             var standardManifestPath = Path.Combine(gedcomRegistriesPath, "manifest", "standard", "manifest-" + GetGedcomVersionString(version) + "-en-US.tsv");
 
             if (!File.Exists(standardManifestPath))
@@ -260,8 +255,7 @@ namespace GedcomCommon
                 throw new FileNotFoundException($"Standard manifest file not found: {standardManifestPath}", standardManifestPath);
             }
 
-            // Read the manifest file to get the list of structure files for this version.
-            var structureFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var filenames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             using (var manifestReader = new StreamReader(standardManifestPath))
             {
                 // Skip header line.
@@ -276,18 +270,36 @@ namespace GedcomCommon
 
                     // The manifest is TSV; the first column is the path.
                     var manifestPath = line.Split('\t')[0].Trim();
-                    if (manifestPath.StartsWith("structure/standard/", StringComparison.OrdinalIgnoreCase))
+                    if (manifestPath.StartsWith(pathPrefix, StringComparison.OrdinalIgnoreCase))
                     {
-                        // Convert the manifest path to just the filename for comparison.
-                        structureFiles.Add(Path.GetFileName(manifestPath));
+                        filenames.Add(Path.GetFileName(manifestPath));
                     }
                 }
             }
 
-            if (structureFiles.Count == 0)
+            if (filenames.Count == 0)
             {
-                throw new InvalidDataException($"No structure files were found in manifest: {standardManifestPath}");
+                throw new InvalidDataException($"No files with prefix \"{pathPrefix}\" were found in manifest: {standardManifestPath}");
             }
+
+            return filenames;
+        }
+
+        public static void LoadAll(GedcomVersion version, string gedcomRegistriesPath = null)
+        {
+            Debug.Assert(version != GedcomVersion.Unknown && version != GedcomVersion.All);
+            if (s_StructureSchemasByVersion[(int)version].Count > 0)
+            {
+                // Already loaded.
+                return;
+            }
+            if (gedcomRegistriesPath == null)
+            {
+                string baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
+                gedcomRegistriesPath = Path.GetFullPath(Path.Combine(baseDirectory, "..", "..", "..", "..", "..", "gedcom7", "external", "GEDCOM-registries"));
+            }
+
+            var structureFiles = LoadManifestFilenames(gedcomRegistriesPath, version, "structure/standard/");
 
             var standardStructurePath = Path.Combine(gedcomRegistriesPath, "structure", "standard");
             string[] files = Directory.GetFiles(standardStructurePath);

--- a/GedcomCommon/GedcomStructureSchema.cs
+++ b/GedcomCommon/GedcomStructureSchema.cs
@@ -255,25 +255,38 @@ namespace GedcomCommon
             }
             var standardManifestPath = Path.Combine(gedcomRegistriesPath, "manifest", "standard", "manifest-" + GetGedcomVersionString(version) + "-en-US.tsv");
 
+            if (!File.Exists(standardManifestPath))
+            {
+                throw new FileNotFoundException($"Standard manifest file not found: {standardManifestPath}", standardManifestPath);
+            }
+
             // Read the manifest file to get the list of structure files for this version.
             var structureFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            if (File.Exists(standardManifestPath))
+            using (var manifestReader = new StreamReader(standardManifestPath))
             {
-                using var manifestReader = new StreamReader(standardManifestPath);
-
                 // Skip header line.
                 manifestReader.ReadLine();
                 string line;
                 while ((line = manifestReader.ReadLine()) != null)
                 {
-                    line = line.Trim();
-                    if (line.StartsWith("structure/standard/", StringComparison.OrdinalIgnoreCase))
+                    if (string.IsNullOrWhiteSpace(line))
+                    {
+                        continue;
+                    }
+
+                    // The manifest is TSV; the first column is the path.
+                    var manifestPath = line.Split('\t')[0].Trim();
+                    if (manifestPath.StartsWith("structure/standard/", StringComparison.OrdinalIgnoreCase))
                     {
                         // Convert the manifest path to just the filename for comparison.
-                        var filename = Path.GetFileName(line);
-                        structureFiles.Add(filename);
+                        structureFiles.Add(Path.GetFileName(manifestPath));
                     }
                 }
+            }
+
+            if (structureFiles.Count == 0)
+            {
+                throw new InvalidDataException($"No structure files were found in manifest: {standardManifestPath}");
             }
 
             var standardStructurePath = Path.Combine(gedcomRegistriesPath, "structure", "standard");

--- a/GedcomLoader/GedcomFile.cs
+++ b/GedcomLoader/GedcomFile.cs
@@ -91,9 +91,11 @@ namespace GedcomLoader
                 {
                     if (line.Contains("2 VERS"))
                     {
+                        var versPayload = line.Substring(line.IndexOf("2 VERS") + "2 VERS".Length).Trim();
+                        var versToken = versPayload.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
                         for (GedcomVersion version = GedcomVersion.V551; version <= GedcomVersion.V71; version++)
                         {
-                            if (line.Contains(GedcomStructureSchema.GetGedcomVersionString(version)))
+                            if (string.Equals(versToken, GedcomStructureSchema.GetGedcomVersionString(version), StringComparison.Ordinal))
                             {
                                 this.GedcomVersion = version;
                                 break;

--- a/GedcomLoader/GedcomFile.cs
+++ b/GedcomLoader/GedcomFile.cs
@@ -96,6 +96,7 @@ namespace GedcomLoader
                             if (line.Contains(GedcomStructureSchema.GetGedcomVersionString(version)))
                             {
                                 this.GedcomVersion = version;
+                                break;
                             }
                         }
                         break;

--- a/GedcomLoader/GedcomFile.cs
+++ b/GedcomLoader/GedcomFile.cs
@@ -91,17 +91,12 @@ namespace GedcomLoader
                 {
                     if (line.Contains("2 VERS"))
                     {
-                        if (line.Contains("7.0"))
+                        for (GedcomVersion version = GedcomVersion.V551; version <= GedcomVersion.V71; version++)
                         {
-                            this.GedcomVersion = GedcomVersion.V70;
-                        }
-                        else if (line.Contains("7.1"))
-                        {
-                            this.GedcomVersion = GedcomVersion.V71;
-                        }
-                        else if (line.Contains("5.5.1"))
-                        {
-                            this.GedcomVersion = GedcomVersion.V551;
+                            if (line.Contains(GedcomStructureSchema.GetGedcomVersionString(version)))
+                            {
+                                this.GedcomVersion = version;
+                            }
                         }
                         break;
                     }


### PR DESCRIPTION
`line.Contains()` on the raw `2 VERS` line causes false-positive matches when one version string is a substring of another (e.g. `"7.1"` matches `"7.10"`).

## Changes
- **`GedcomLoader/GedcomFile.cs`**: Replace substring matching with exact token extraction — parse the payload after `"2 VERS"`, split on whitespace to isolate the version token, then compare with `string.Equals(..., StringComparison.Ordinal)` and `break` on first match.

```csharp
// Before
if (line.Contains(GedcomStructureSchema.GetGedcomVersionString(version)))

// After
var versToken = line.Substring(line.IndexOf("2 VERS") + "2 VERS".Length)
                    .Trim()
                    .Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries)
                    .FirstOrDefault();
if (string.Equals(versToken, GedcomStructureSchema.GetGedcomVersionString(version), StringComparison.Ordinal))
```